### PR TITLE
fix: Argument must be of type iterable|string, null given

### DIFF
--- a/src/AutoGenerateAccessor.php
+++ b/src/AutoGenerateAccessor.php
@@ -39,6 +39,11 @@ class AutoGenerateAccessor implements ListenerInterface
 
     public function process(object $event): void
     {
+        $config = $this->container->get(ConfigInterface::class);
+        if (empty($config->get('php-accessor.proxy_root_directory'))) {
+            return;
+        }
+
         $pid = pcntl_fork();
         if ($pid == -1) {
             throw new Exception('The process fork failed');
@@ -46,7 +51,6 @@ class AutoGenerateAccessor implements ListenerInterface
 
         if ($pid) {
             pcntl_wait($status);
-            $config = $this->container->get(ConfigInterface::class);
             $proxyDir = $config->get('php-accessor.proxy_root_directory') . DIRECTORY_SEPARATOR . 'proxy';
             if (! is_dir($proxyDir)) {
                 return;


### PR DESCRIPTION
`composer` 安装后，发布配置文件报错如下：
 
```text
/hyperf30-swoole # php bin/hyperf.php vendor:publish free2one/hyperf-php-accessor
PHP Fatal error:  Uncaught TypeError: Symfony\Component\Filesystem\Filesystem::exists(): Argument #1 ($files) must be of type iterable|string, null given, called in /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php on line 100 and defined in /hyperf30-swoole/vendor/symfony/filesystem/Filesystem.php:103
Stack trace:
#0 /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php(100): Symfony\Component\Filesystem\Filesystem->exists()
#1 /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php(74): Hyperf\PhpAccessor\AutoGenerateAccessor->removeProxies()
#2 /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php(67): Hyperf\PhpAccessor\AutoGenerateAccessor->genProxyFile()
#3 /hyperf30-swoole/vendor/hyperf/event/src/EventDispatcher.php(48): Hyperf\PhpAccessor\AutoGenerateAccessor->process()
#4 /hyperf30-swoole/vendor/hyperf/framework/src/ApplicationFactory.php(28): Hyperf\Event\EventDispatcher->dispatch()
#5 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/FactoryResolver.php(56): Hyperf\Framework\ApplicationFactory->__invoke()
#6 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(62): Hyperf\Di\Resolver\FactoryResolver->resolve()
#7 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/DepthGuard.php(73): Hyperf\Di\Resolver\ResolverDispatcher->Hyperf\Di\Resolver\{closure}()
#8 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(63): Hyperf\Di\Resolver\DepthGuard->call()
#9 /hyperf30-swoole/vendor/hyperf/di/src/Container.php(194): Hyperf\Di\Resolver\ResolverDispatcher->resolve()
#10 /hyperf30-swoole/vendor/hyperf/di/src/Container.php(82): Hyperf\Di\Container->resolveDefinition()
#11 /hyperf30-swoole/vendor/hyperf/di/src/Container.php(127): Hyperf\Di\Container->make()
#12 /hyperf30-swoole/bin/hyperf.php(21): Hyperf\Di\Container->get()
#13 /hyperf30-swoole/bin/hyperf.php(23): {closure}()
#14 {main}
  thrown in /hyperf30-swoole/vendor/symfony/filesystem/Filesystem.php on line 103

Fatal error: Uncaught TypeError: Symfony\Component\Filesystem\Filesystem::exists(): Argument #1 ($files) must be of type iterable|string, null given, called in /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php on line 100 and defined in /hyperf30-swoole/vendor/symfony/filesystem/Filesystem.php:103
Stack trace:
#0 /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php(100): Symfony\Component\Filesystem\Filesystem->exists()
#1 /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php(74): Hyperf\PhpAccessor\AutoGenerateAccessor->removeProxies()
#2 /hyperf30-swoole/vendor/free2one/hyperf-php-accessor/src/AutoGenerateAccessor.php(67): Hyperf\PhpAccessor\AutoGenerateAccessor->genProxyFile()
#3 /hyperf30-swoole/vendor/hyperf/event/src/EventDispatcher.php(48): Hyperf\PhpAccessor\AutoGenerateAccessor->process()
#4 /hyperf30-swoole/vendor/hyperf/framework/src/ApplicationFactory.php(28): Hyperf\Event\EventDispatcher->dispatch()
#5 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/FactoryResolver.php(56): Hyperf\Framework\ApplicationFactory->__invoke()
#6 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(62): Hyperf\Di\Resolver\FactoryResolver->resolve()
#7 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/DepthGuard.php(73): Hyperf\Di\Resolver\ResolverDispatcher->Hyperf\Di\Resolver\{closure}()
#8 /hyperf30-swoole/vendor/hyperf/di/src/Resolver/ResolverDispatcher.php(63): Hyperf\Di\Resolver\DepthGuard->call()
#9 /hyperf30-swoole/vendor/hyperf/di/src/Container.php(194): Hyperf\Di\Resolver\ResolverDispatcher->resolve()
#10 /hyperf30-swoole/vendor/hyperf/di/src/Container.php(82): Hyperf\Di\Container->resolveDefinition()
#11 /hyperf30-swoole/vendor/hyperf/di/src/Container.php(127): Hyperf\Di\Container->make()
#12 /hyperf30-swoole/bin/hyperf.php(21): Hyperf\Di\Container->get()
#13 /hyperf30-swoole/bin/hyperf.php(23): {closure}()
#14 {main}
  thrown in /hyperf30-swoole/vendor/symfony/filesystem/Filesystem.php on line 103
[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\PhpAccessor\AutoGenerateAccessor listener.
[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\DbConnection\Listener\RegisterConnectionResolverListener listener.
[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\ExceptionHandler\Listener\ExceptionHandlerListener listener.
[DEBUG] Event Hyperf\Framework\Event\BootApplication handled by Hyperf\Config\Listener\RegisterPropertyHandlerListener listener.
[free2one/hyperf-php-accessor] publishes [config] successfully.
```

